### PR TITLE
Bumps spring-boot from 2.1.9 RELEASE to 2.3.4 RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.9.RELEASE</version>
+        <version>2.3.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/src/main/kotlin/no/nav/dokgen/configuration/DelayedShutdownHook.kt
+++ b/src/main/kotlin/no/nav/dokgen/configuration/DelayedShutdownHook.kt
@@ -1,6 +1,5 @@
 package no.nav.dokgen.configuration
 
-import no.nav.dokgen.services.TemplateService
 import org.slf4j.LoggerFactory
 import org.springframework.context.ConfigurableApplicationContext
 

--- a/src/main/kotlin/no/nav/dokgen/configuration/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/dokgen/configuration/SwaggerConfig.kt
@@ -2,11 +2,16 @@ package no.nav.dokgen.configuration
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.hateoas.client.LinkDiscoverers
+import org.springframework.hateoas.mediatype.collectionjson.CollectionJsonLinkDiscoverer
+import org.springframework.plugin.core.SimplePluginRegistry
 import springfox.documentation.builders.PathSelectors
 import springfox.documentation.builders.RequestHandlerSelectors
 import springfox.documentation.spi.DocumentationType
 import springfox.documentation.spring.web.plugins.Docket
 import springfox.documentation.swagger2.annotations.EnableSwagger2
+
 
 @Configuration
 @EnableSwagger2
@@ -18,5 +23,12 @@ class SwaggerConfig {
             .apis(RequestHandlerSelectors.any())
             .paths(PathSelectors.any())
             .build()
+    }
+
+    @Primary
+    @Bean
+    fun discoverers(): LinkDiscoverers? {
+        val plugins = listOf(CollectionJsonLinkDiscoverer())
+        return LinkDiscoverers(SimplePluginRegistry.create(plugins))
     }
 }

--- a/src/main/kotlin/no/nav/dokgen/configuration/WebConfig.kt
+++ b/src/main/kotlin/no/nav/dokgen/configuration/WebConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.dokgen.configuration
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer

--- a/src/main/kotlin/no/nav/dokgen/controller/IndexController.kt
+++ b/src/main/kotlin/no/nav/dokgen/controller/IndexController.kt
@@ -1,10 +1,10 @@
 package no.nav.dokgen.controller
 
 import no.nav.dokgen.resources.IndexResource
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.hateoas.EntityModel
 import org.springframework.hateoas.Link
-import org.springframework.hateoas.Resource
-import org.springframework.hateoas.mvc.ControllerLinkBuilder
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,16 +19,16 @@ class IndexController(
 ) {
     @ResponseStatus(HttpStatus.OK)
     @RequestMapping(value = ["/"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun listTemplates(): Resource<IndexResource> {
-        val link = Link(servletRequest.requestURL.toString() + "swagger-ui.html")
+    fun listTemplates(): EntityModel<IndexResource> {
+        val link = Link.of(servletRequest.requestURL.toString() + "swagger-ui.html")
             .withRel("swagger-ui")
-        return Resource(
+        return EntityModel.of(
             IndexResource("dokgen"),
-            ControllerLinkBuilder.linkTo(ControllerLinkBuilder.methodOn(TemplateController::class.java).listTemplates())
+            linkTo(methodOn(TemplateController::class.java).listTemplates())
                 .withRel("templates"),
             link,
-            ControllerLinkBuilder.linkTo(
-                ControllerLinkBuilder.methodOn(Swagger2Controller::class.java)
+            linkTo(
+                methodOn(Swagger2Controller::class.java)
                     .getDocumentation("default", servletRequest)
             ).withRel("swagger-doc")
         )

--- a/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
+++ b/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
@@ -14,11 +14,10 @@ import no.nav.dokgen.util.DocFormat
 import no.nav.dokgen.util.HttpUtil.genHeaders
 import no.nav.dokgen.util.HttpUtil.genHtmlHeaders
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.hateoas.Resource
+import org.springframework.hateoas.EntityModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.util.*
 
 @RestController
 class TemplateController(
@@ -35,7 +34,7 @@ class TemplateController(
     @ResponseStatus(
         HttpStatus.OK
     )
-    fun listTemplates(): List<Resource<TemplateResource>> {
+    fun listTemplates(): List<EntityModel<TemplateResource>> {
         return templateService.listTemplates().map{
             templateLinks(it)
         }
@@ -43,7 +42,7 @@ class TemplateController(
 
     @GetMapping(value = ["/template/{templateName}/testdata"])
     @ApiOperation(value = "Hent de forskjellige testdataene for spesifikk mal")
-    fun listTestData(@PathVariable templateName: String): List<Resource<TestDataResource>> {
+    fun listTestData(@PathVariable templateName: String): List<EntityModel<TestDataResource>> {
         return testdataService.listTestData(templateName).map {
             testDataLinks(templateName, it)
         }

--- a/src/main/kotlin/no/nav/dokgen/services/HateoasService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/HateoasService.kt
@@ -3,15 +3,13 @@ package no.nav.dokgen.services
 import no.nav.dokgen.controller.TemplateController
 import no.nav.dokgen.resources.TemplateResource
 import no.nav.dokgen.resources.TestDataResource
-import org.springframework.hateoas.Resource
-import org.springframework.hateoas.mvc.ControllerLinkBuilder
-import org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo
-import org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn
+import org.springframework.hateoas.EntityModel
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn
 
 object HateoasService {
-    fun templateLinks(templateName: String): Resource<TemplateResource> {
-        return Resource(
-            TemplateResource(templateName),
+    fun templateLinks(templateName: String): EntityModel<TemplateResource> {
+        return EntityModel.of(TemplateResource(templateName),
             linkTo(
                 methodOn(TemplateController::class.java).getTemplateAsMarkdown(templateName)
             ).withSelfRel(),
@@ -30,8 +28,8 @@ object HateoasService {
         )
     }
 
-    fun testDataLinks(templateName: String, testDataName: String): Resource<TestDataResource> {
-        return Resource(
+    fun testDataLinks(templateName: String, testDataName: String): EntityModel<TestDataResource> {
+        return EntityModel.of(
             TestDataResource(templateName, testDataName),
             linkTo(
                 methodOn(TemplateController::class.java).previewHtml(templateName, testDataName)

--- a/src/main/kotlin/no/nav/dokgen/services/JsonService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/JsonService.kt
@@ -8,6 +8,8 @@ import no.nav.dokgen.util.FileStructureUtil.getTemplateSchemaPath
 import org.everit.json.schema.Schema
 import org.everit.json.schema.ValidationException
 import org.everit.json.schema.loader.SchemaLoader
+import org.json.JSONObject
+import org.json.JSONTokener
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -20,8 +22,6 @@ import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.util.*
 import java.util.stream.Collectors
-import org.json.JSONObject
-import org.json.JSONTokener
 
 @Service
 class JsonService @Autowired constructor(

--- a/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.util.*
 import java.util.function.Function
 import java.util.stream.Collectors
 

--- a/src/test/kotlin/no/nav/dokgen/DokgenTests.kt
+++ b/src/test/kotlin/no/nav/dokgen/DokgenTests.kt
@@ -2,9 +2,9 @@ package no.nav.dokgen
 
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
 
 @RunWith(SpringRunner::class)
 @SpringBootTest(classes = [DokgenApplication::class])

--- a/src/test/kotlin/no/nav/dokgen/services/HateoasServiceTests.kt
+++ b/src/test/kotlin/no/nav/dokgen/services/HateoasServiceTests.kt
@@ -17,9 +17,9 @@ class HateoasServiceTests {
     @Test
     fun skal_returnere_template_links() {
         val links = templateLinks("test")
-        Assertions.assertThat(links.links.size).isGreaterThan(0)
+        Assertions.assertThat(links.links).isNotEmpty
         for (link in links.links) {
-            Assertions.assertThat(link.rel).isNotEmpty
+            Assertions.assertThat(link.rel).isNotNull
             Assertions.assertThat(link.href).isNotEmpty
         }
     }
@@ -27,9 +27,9 @@ class HateoasServiceTests {
     @Test
     fun skal_returnere_testdata_links() {
         val links = testDataLinks("test", "test")
-        Assertions.assertThat(links.links.size).isGreaterThan(0)
+        Assertions.assertThat(links.links).isNotEmpty
         for (link in links.links) {
-            Assertions.assertThat(link.rel).isNotEmpty
+            Assertions.assertThat(link.rel).isNotNull
             Assertions.assertThat(link.href).isNotEmpty
         }
     }


### PR DESCRIPTION
Bumps spring-boot

Spring HATEOAS updated, which created a couple of problems. The most difficult one is the bean dependency error for the method linkDiscoverers(). I googled and found a solution:
https://stackoverflow.com/a/61631873

However, it seems not a perfect solution, nor do I understand it entirely. I think an official patch is required for this error.