### PR TITLE
export metrics endpoints to avoid error logs

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,18 @@
 path.content.root: ./content/
 write.access: false
 
+management:
+  endpoint.health.show-details: always
+  endpoints.web:
+    exposure.include: info, health, metrics, prometheus
+    base-path: "/internal"
+  metrics.export.prometheus.enabled: true
+  metrics:
+    web:
+      server:
+        request:
+          autotime:
+            enabled: true
+
 logging:
   config: "classpath:logback-spring.xml"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ management:
   endpoint.health.show-details: always
   endpoints.web:
     exposure.include: info, health, metrics, prometheus
-    base-path: "/internal"
+    base-path: "/actuator"
   metrics.export.prometheus.enabled: true
   metrics:
     web:


### PR DESCRIPTION
Export metrics endpoints so prometheus won't complain.

Actually I am not sure if we should disable prometheus in familie-ba-dokgen and familie-ef-maler because dokgen actually did not use metrics.
There is inconsistency with base url for health, info and prometheus in both familie-ba-dokgen and familie-ef-maler naiserator, where the former two use "/actuator" while the latter uses "/internal". By applying this PR, both familie-ba-dokgen and familie-ef-maler need adaptation to eliminate the inconsistency.