### PR TITLE
Allow encoded slash in urls. This makes it possible to have templates…

### DIFF
--- a/src/main/kotlin/no/nav/dokgen/configuration/WebConfig.kt
+++ b/src/main/kotlin/no/nav/dokgen/configuration/WebConfig.kt
@@ -1,14 +1,26 @@
 package no.nav.dokgen.configuration
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.util.UrlPathHelper
 
 @Configuration
-class WebConfig (
-    val loggerInterceptor: LoggerInterceptor
-): WebMvcConfigurer {
+class WebConfig(val loggerInterceptor: LoggerInterceptor) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(loggerInterceptor)
+    }
+
+}
+
+@Configuration
+@ConditionalOnProperty("allow-encoded-slash")
+class EnableSlashInURLPath : WebMvcConfigurer {
+    override fun configurePathMatch(configurer: PathMatchConfigurer) {
+        val urlPathHelper = UrlPathHelper()
+        urlPathHelper.isUrlDecode = false
+        configurer.setUrlPathHelper(urlPathHelper)
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,4 +1,6 @@
 path.content.root: ./content/
 write.access: true
+allow-encoded-slash: ${ALLOW_ENCODED_SLASH:false}
+
 logging:
   config: "classpath:logback-dev.xml"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 path.content.root: ./content/
 write.access: false
+allow-encoded-slash: ${ALLOW_ENCODED_SLASH:false}
 
 management:
   endpoint.health.show-details: always

--- a/src/test/kotlin/no/nav/dokgen/services/TemplateServiceTests.kt
+++ b/src/test/kotlin/no/nav/dokgen/services/TemplateServiceTests.kt
@@ -2,9 +2,8 @@ package no.nav.dokgen.services
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import no.nav.dokgen.services.DocumentGeneratorServiceTests
-import no.nav.dokgen.util.FileStructureUtil.getTemplatePath
 import no.nav.dokgen.util.FileStructureUtil.getTemplateRootPath
+import no.nav.dokgen.util.FileStructureUtil.getTemplatePath
 import no.nav.dokgen.util.FileStructureUtil.getTemplateSchemaPath
 import org.apache.commons.io.FileUtils
 import org.assertj.core.api.Assertions
@@ -70,7 +69,6 @@ class TemplateServiceTests {
     }
 
     @Test
-    @Throws(IOException::class)
     fun skalReturnereMal() {
         val malPath = templateRoot.resolve("MAL")
         Files.createDirectories(malPath)
@@ -80,6 +78,22 @@ class TemplateServiceTests {
 
         // expect
         val (_, content) = malService.getTemplate("MAL")
+
+        // when
+        Assertions.assertThat(content).isEqualTo("maldata")
+    }
+
+    @Test
+    fun skalReturnereMalDerMalnavnErEnPath() {
+        val malpathString = "EN/MAL/SOM/LIGGER/HER"
+        val malPath = templateRoot.resolve(malpathString)
+        Files.createDirectories(malPath)
+        val templatePath = getTemplatePath(contentRoot, malpathString)
+        Files.write(templatePath, "maldata".toByteArray())
+
+
+        // expect
+        val (_, content) = malService.getTemplate(malpathString)
 
         // when
         Assertions.assertThat(content).isEqualTo("maldata")


### PR DESCRIPTION
… in subdirectories.

Must be enabled using env variable ALLOW_ENCODED_SLASH.

Only tested for create-pdf