### PR TITLE
Oppdaterer java distribusjon til Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM navikt/java:17
+FROM ghcr.io/navikt/baseimages/temurin:17
 COPY target/*.jar app.jar
 COPY content content


### PR DESCRIPTION
OpenJDK er deprecated og patches ikke lenger
Temurin imagene er patched fortløpende og er allerede OpenSSL patchet.