### PR TITLE
Bruker distroless:nonroot som baseimage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM gcr.io/distroless/java21-debian12:nonroot
+# Healtcheck lokalt/test
+COPY --from=busybox:stable-musl /bin/wget /usr/bin/wget
+
+# Working dir for RUN, CMD, ENTRYPOINT, COPY and ADD (required because of nonroot user cannot run commands in root)
+WORKDIR /app
+
 COPY target/*.jar app.jar
 COPY content content
+
+CMD ["app.jar"]


### PR DESCRIPTION
Prøver meg på et distroless java21 image her også.

Image testet lokalt og ting ser ut til å virke greit.  