### PR TITLE
Fjerner logging av *Using fallback font LiberationSans for base font xyz*

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -33,5 +33,7 @@
     <logger name="no.nav" level="WARN"/>
     <logger name="no.nav.dokgen" level="INFO"/>
     <logger name="org.apache" level="INFO"/>
+    <logger name="org.apache.pdfbox.pdmodel.font.PDType1Font" level="ERROR"/>
+    <logger name="org.apache.pdfbox.pdmodel.font.FileSystemFontProvider" level="ERROR"/>
 
 </configuration>

--- a/up.sh
+++ b/up.sh
@@ -3,4 +3,4 @@
 docker stop familie-dokgen; docker rm familie-dokgen
 mvn -B -Dfile.encoding=UTF-8 -DinstallAtEnd=true -DdeployAtEnd=true  -DskipTests clean install
 docker build -t navikt/dokgen .
-docker run -p 7281:8080 -d --name familie-dokgen navikt/dokgen
+docker run -p 7281:8080 -d --name familie-dokgen -e SPRING_PROFILES_ACTIVE=dev navikt/dokgen


### PR DESCRIPTION
Er ikke noe feil med generering av PDF bortsett fra at PDFbox finner ikke standard fontene i distroless image.