### PR TITLE
Bytt til Openhtmltopdf-versjon som bruker pdfbox2 for compliance

### DIFF
--- a/.m2/maven-settings.xml
+++ b/.m2/maven-settings.xml
@@ -9,6 +9,11 @@
             <username>${GITHUB_USERNAME}</username>
             <password>${GITHUB_TOKEN}</password>
         </server>
+        <server>
+            <id>at.datenwort.openhtmltopdf</id>
+            <username>${GITHUB_USERNAME}</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
     </servers>
 
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <felles.version>2.20231201131108_ea25dd3</felles.version>
         <handlebar.version>4.3.1</handlebar.version>
         <kotlin.version>1.9.21</kotlin.version>
-        <openhtml.version>1.1.4</openhtml.version>
+        <openhtml.version>pdfbox2-65c2c5010f84b2daa5821971c9c68cd330463830</openhtml.version>
         <commonmark.version>0.21.0</commonmark.version>
     </properties>
     <dependencies>
@@ -88,11 +88,6 @@
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <version>${openhtml.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>3.0.1</version>
-        </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
@@ -143,7 +138,7 @@
         </repository>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/navikt/familie-felles</url>
+            <url>https://maven.pkg.github.com</url>
         </repository>
     </repositories>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,16 +128,20 @@
     </dependencies>
     <repositories>
         <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/navikt</url>
+        </repository>
+        <repository>
+            <id>at.datenwort.openhtmltopdf</id>
+            <url>https://maven.pkg.github.com/openhtmltopdf/openhtmltopdf</url>
+        </repository>
+        <repository>
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com</url>
         </repository>
     </repositories>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.3</version>
         <relativePath/>
     </parent>
     <artifactId>dokgen</artifactId>
@@ -17,10 +17,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <felles.version>2.20231201131108_ea25dd3</felles.version>
-        <handlebar.version>4.3.1</handlebar.version>
-        <kotlin.version>1.9.21</kotlin.version>
+        <handlebar.version>4.4.0</handlebar.version>
+        <kotlin.version>1.9.23</kotlin.version>
         <openhtml.version>pdfbox2-65c2c5010f84b2daa5821971c9c68cd330463830</openhtml.version>
-        <commonmark.version>0.21.0</commonmark.version>
+        <commonmark.version>0.22.0</commonmark.version>
     </properties>
     <dependencies>
         <dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -65,13 +65,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.jknack</groupId>
-            <artifactId>handlebars-jackson2</artifactId>
+            <artifactId>handlebars-jackson</artifactId>
             <version>${handlebar.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.17.1</version>
         </dependency>
         <dependency>
             <groupId>at.datenwort.openhtmltopdf</groupId>
@@ -88,11 +83,20 @@
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <version>${openhtml.version}</version>
         </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.15.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.everit-org.json-schema</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
+            <version>1.14.4</version>
         </dependency>
         <dependency>
             <groupId>org.commonmark</groupId>
@@ -103,11 +107,6 @@
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark-ext-gfm-tables</artifactId>
             <version>${commonmark.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
-            <version>1.14.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/navikt</url>
+            <url>https://maven.pkg.github.com/navikt/familie-felles</url>
         </repository>
         <repository>
             <id>at.datenwort.openhtmltopdf</id>

--- a/src/main/kotlin/no/nav/dokgen/services/DocumentGeneratorService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/DocumentGeneratorService.kt
@@ -94,6 +94,7 @@ class DocumentGeneratorService @Autowired constructor(
                     .useSVGDrawer(BatikSVGDrawer())
                     .useColorProfile(colorProfile)
                     .usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_2_U)
+                    .usePdfUaAccessbility(true)
                     .toStream(os)
                     .run()
             }

--- a/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
@@ -3,7 +3,6 @@ package no.nav.dokgen.services
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.jknack.handlebars.Context
 import com.github.jknack.handlebars.Handlebars
-import com.github.jknack.handlebars.JsonNodeValueResolver
 import com.github.jknack.handlebars.Template
 import com.github.jknack.handlebars.context.FieldValueResolver
 import com.github.jknack.handlebars.context.JavaBeanValueResolver
@@ -12,6 +11,7 @@ import com.github.jknack.handlebars.context.MethodValueResolver
 import com.github.jknack.handlebars.helper.ConditionalHelpers
 import com.github.jknack.handlebars.helper.StringHelpers
 import com.github.jknack.handlebars.io.FileTemplateLoader
+import com.github.jknack.handlebars.jackson.JsonNodeValueResolver
 import no.nav.dokgen.controller.api.CreateDocumentRequest
 import no.nav.dokgen.exceptions.DokgenNotFoundException
 import no.nav.dokgen.handlebars.CustomHelpers

--- a/src/test/kotlin/no/nav/dokgen/services/TemplateServiceTests.kt
+++ b/src/test/kotlin/no/nav/dokgen/services/TemplateServiceTests.kt
@@ -3,7 +3,7 @@ package no.nav.dokgen.services
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.github.jknack.handlebars.Context
-import com.github.jknack.handlebars.JsonNodeValueResolver
+import com.github.jknack.handlebars.jackson.JsonNodeValueResolver
 import no.nav.dokgen.util.FileStructureUtil.getTemplateRootPath
 import no.nav.dokgen.util.FileStructureUtil.getTemplatePath
 import no.nav.dokgen.util.FileStructureUtil.getTemplateSchemaPath


### PR DESCRIPTION
Foreldrepenger opplever dårlig PDF/A-2U compliance pga mangelfull mapping fra glypher til unicode (utover manglende compliance påvirker det skjermlesere+kopiering av tekst). Dette gjaldt noen ligaturer i fonten som ble tatt i bruk med pdfbox3. 

Pdfgen-core har laget en branch av openhtmltopdf som bruker pdfbox2. Foreslår bytte til den inntil videre.

Bumper også noen dependencies.