### PR TITLE
Template path queryparam

### DIFF
--- a/src/main/kotlin/no/nav/dokgen/configuration/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/dokgen/configuration/ApplicationConfig.kt
@@ -34,17 +34,6 @@ class ApplicationConfig {
         return filterRegistration
     }
 
-    @Bean
-    @ConditionalOnProperty("allow-encoded-slash")
-    fun enableSlashInURLPath(): WebMvcConfigurer {
-        return object : WebMvcConfigurer {
-            override fun configurePathMatch(configurer: PathMatchConfigurer) {
-                val urlPathHelper = UrlPathHelper()
-                urlPathHelper.isUrlDecode = false
-                configurer.setUrlPathHelper(urlPathHelper)
-            }
-        }
-    }
     companion object {
         private val log = LoggerFactory.getLogger(ApplicationConfig::class.java)
     }

--- a/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
+++ b/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
@@ -61,6 +61,14 @@ class TemplateController(
         return ResponseEntity(pdf, genHeaders(DocFormat.PDF, templateName, false), HttpStatus.OK)
     }
 
+    @PostMapping(value = ["/template/create-pdf"], consumes = ["application/json"])
+    @Operation(summary = "Lager en PDF av flettefeltene og malen. Støtter mal i undermapper", description = "PDF er av versjonen PDF/A")
+    fun createPdfFromPath(@RequestParam("templatePath") templatePath: String, @RequestBody mergeFields: String?): ResponseEntity<*> {
+        val pdf = templateService.createPdf(templatePath, mergeFields)
+        return ResponseEntity(pdf, genHeaders(DocFormat.PDF, templatePath, false), HttpStatus.OK)
+    }
+
+
     @PostMapping(value = ["/template/{templateName}/{variation}/create-pdf-variation"], consumes = ["application/json"])
     @Operation(
         summary = "Lager en PDF av flettefeltene og malen med angitt variation.",
@@ -171,6 +179,13 @@ class TemplateController(
     fun previewPdf(@PathVariable templateName: String, @PathVariable testDataName: String): ResponseEntity<*> {
         val mergeFields = testdataService.getTestData(templateName, testDataName)
         return createPdf(templateName, mergeFields)
+    }
+
+    @GetMapping(value = ["/template/preview-pdf"])
+    @Operation(summary = "Generer malen som PDF med test data fra template som path")
+    fun previewPdfFromPath(@RequestParam templatePath: String, @RequestParam testDataName: String): ResponseEntity<*> {
+        val mergeFields = testdataService.getTestData(templatePath, testDataName)
+        return createPdf(templatePath, mergeFields)
     }
 
     @GetMapping(value = ["/template/{templateName}/preview-html/{testDataName}"])

--- a/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
+++ b/src/main/kotlin/no/nav/dokgen/controller/TemplateController.kt
@@ -63,7 +63,7 @@ class TemplateController(
 
     @PostMapping(value = ["/template/create-pdf"], consumes = ["application/json"])
     @Operation(summary = "Lager en PDF av flettefeltene og malen. Støtter mal i undermapper", description = "PDF er av versjonen PDF/A")
-    fun createPdfFromPath(@RequestParam("templatePath") templatePath: String, @RequestBody mergeFields: String?): ResponseEntity<*> {
+    fun createPdfFromPath(@RequestParam templatePath: String, @RequestBody mergeFields: String?): ResponseEntity<*> {
         val pdf = templateService.createPdf(templatePath, mergeFields)
         return ResponseEntity(pdf, genHeaders(DocFormat.PDF, templatePath, false), HttpStatus.OK)
     }

--- a/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
+++ b/src/main/kotlin/no/nav/dokgen/services/TemplateService.kt
@@ -125,12 +125,12 @@ class TemplateService @Autowired internal constructor(
         )
     }
 
-    fun getTemplate(templateName: String): TemplateResource {
-        return getTemplate(templateName, getTemplatePath(contentRoot, templateName))
+    fun getTemplate(templatePath: String): TemplateResource {
+        return getTemplate(templatePath, getTemplatePath(contentRoot, templatePath))
     }
 
-    fun getTemplate(templateName: String, variation: String): TemplateResource {
-        return getTemplate(templateName, getTemplatePath(contentRoot, templateName, variation))
+    fun getTemplate(templatePath: String, variation: String): TemplateResource {
+        return getTemplate(templatePath, getTemplatePath(contentRoot, templatePath, variation))
     }
 
     private fun getTemplate(templateName: String, templatePath: Path): TemplateResource {
@@ -175,9 +175,9 @@ class TemplateService @Autowired internal constructor(
         return createMarkdown(templateName, mergefields, templateResource)
     }
 
-    fun createMarkdown(templateName: String, mergefields: String, variation: String): String? {
-        val templateResource = getTemplate(templateName, variation)
-        return createMarkdown(templateName, mergefields, templateResource)
+    fun createMarkdown(templatePath: String, mergefields: String, variation: String): String? {
+        val templateResource = getTemplate(templatePath, variation)
+        return createMarkdown(templatePath, mergefields, templateResource)
     }
 
     private fun createMarkdown(templateName: String, mergefields: String, templateResource: TemplateResource): String? {

--- a/src/main/kotlin/no/nav/dokgen/util/FileStructureUtil.kt
+++ b/src/main/kotlin/no/nav/dokgen/util/FileStructureUtil.kt
@@ -8,16 +8,16 @@ object FileStructureUtil {
         return contentRoot.resolve("templates/$templateName/schema.json")
     }
 
-    fun getTemplatePath(contentRoot: Path, templateName: String): Path {
-        return getTemplatePath(contentRoot, templateName, DEFAULT_VARIATION)
+    fun getTemplatePath(contentRoot: Path, templatePath: String): Path {
+        return getTemplatePath(contentRoot, templatePath, DEFAULT_VARIATION)
     }
 
-    fun getTemplatePath(contentRoot: Path, templateName: String, variation: String): Path {
-        return contentRoot.resolve("templates/$templateName/$variation.hbs")
+    fun getTemplatePath(contentRoot: Path, templatePath: String, variation: String): Path {
+        return contentRoot.resolve("templates/$templatePath/$variation.hbs")
     }
 
-    fun getTestDataPath(contentRoot: Path, templateName: String, testDataName: String): Path {
-        return contentRoot.resolve("templates/$templateName/testdata/$testDataName.json")
+    fun getTestDataPath(contentRoot: Path, templatePath: String, testDataName: String): Path {
+        return contentRoot.resolve("templates/$templatePath/testdata/$testDataName.json")
     }
 
     fun getTestDataRootPath(contentRoot: Path, templateName: String?): Path {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,5 @@
 path.content.root: ./content/
 write.access: false
-allow-encoded-slash: ${ALLOW_ENCODED_SLASH:false}
 
 management:
   endpoint.health.show-details: always


### PR DESCRIPTION
Nye endepunkter som støtter template i path slik at maler kan grupperes i undermapper.
Fjerner støtte for å tillate slash i path (som uansett er bad practice)