### PR TITLE
chore: ruller tilbake til tidligere base image pga meldte problemer med æøå i pathen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM ghcr.io/navikt/fp-baseimages/distroless:21
+FROM gcr.io/distroless/java21-debian12:nonroot
+# Healtcheck lokalt/test
+COPY --from=busybox:stable-musl /bin/wget /usr/bin/wget
+
+# Working dir for RUN, CMD, ENTRYPOINT, COPY and ADD (required because of nonroot user cannot run commands in root)
+WORKDIR /app
 
 COPY target/*.jar app.jar
 COPY content content


### PR DESCRIPTION
Det er den samme koden som fp-baseimages bruker uten å sette LANG og andre locales.